### PR TITLE
Fix video not rendered with Free version in Moodle app

### DIFF
--- a/appjs/view_init.js
+++ b/appjs/view_init.js
@@ -33,7 +33,7 @@
         this.element = element;
         this.angularComponent = angularComponent;
         this.cmid = element.getAttribute('data-session');
-        this.hasPro = element.getAttribute('data-has-pro');
+        this.hasPro = element.getAttribute('data-has-pro') && element.getAttribute('data-has-pro') !== '0';
         this.resumeTime = element.getAttribute('data-resume-time');
         this.player = null;
         this.playing = false;


### PR DESCRIPTION
When using the free version, the value of "data-has-pro" is "0" (string), and that is considered true in JS. This makes the app call a WS that doesn't exist (the pro one), so it fails and the video isn't rendered.